### PR TITLE
feat: Add custom SSH port to deployment config

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,7 @@ jobs:
           echo "$SSH_PRIVATE_KEY" > $TEMP_SSH_DIR/id_rsa
           chmod 600 $TEMP_SSH_DIR/id_rsa
           echo "StrictHostKeyChecking no" > $TEMP_SSH_DIR/config
+          echo "Port 22222" >> $TEMP_SSH_DIR/config
           echo "TEMP_SSH_DIR=$TEMP_SSH_DIR" >> $GITHUB_ENV
 
       - name: Deploy to NixOS Server


### PR DESCRIPTION
Add port 22222 to SSH config in GitHub Actions workflow

This change ensures the deployment process uses the correct SSH
port when connecting to the NixOS server. It addresses connectivity
issues caused by non-standard SSH port configurations.