### PR TITLE
fix: Replace dos2unix with sed for line ending conversion

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,8 +37,8 @@ jobs:
           cd $GITHUB_WORKSPACE
 
           # Convert scripts to Unix format (in case they were edited on Windows)
-          dos2unix .github/workflows/deploy-script.sh
-          dos2unix deploy.sh
+          sed -i 's/\r$//' .github/workflows/deploy-script.sh
+          sed -i 's/\r$//' deploy.sh
 
           # Copy both scripts to server
           scp -i $TEMP_SSH_DIR/id_rsa -F $TEMP_SSH_DIR/config \


### PR DESCRIPTION
Replace dos2unix commands with sed equivalents to convert
line endings from Windows to Unix format. This change
improves compatibility and removes the dependency on the
dos2unix utility, which may not be available on all systems.