### PR TITLE
feat: Update deploy script paths for NixOS

### DIFF
--- a/.github/workflows/deploy-script.sh
+++ b/.github/workflows/deploy-script.sh
@@ -21,9 +21,9 @@ else
 fi
 
 echo "Ensuring deploy script is executable"
-chmod +x /home/$SERVER_USER/deploy.sh
+chmod +x /home/nixos/deploy.sh
 
 echo "Running deploy script"
-bash /home/$SERVER_USER/deploy.sh
+bash /home/nixos/deploy.sh
 
 echo "Deployment complete"


### PR DESCRIPTION
Update paths in deploy-script.sh to use /home/nixos instead of
dynamic $SERVER_USER. This change ensures consistent deployment
on NixOS systems, improving reliability and reducing potential
errors related to variable expansion.