### PR TITLE
fix: Update deployment script paths

### DIFF
--- a/.github/workflows/deploy-script.sh
+++ b/.github/workflows/deploy-script.sh
@@ -3,7 +3,7 @@ set -e
 
 echo "Starting deployment script"
 
-REPO_DIR=~/nixos-config
+REPO_DIR=/home/nixos/nixos-config
 
 if [ -z "$REPO_URL" ]; then
   echo "Error: REPO_URL is not set"

--- a/deploy.sh
+++ b/deploy.sh
@@ -10,7 +10,7 @@ if [ "$EUID" -ne 0 ]; then
 fi
 
 # Define source and destination directories
-SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC_DIR="/home/nixos/nixos-config"
 DEST_DIR="/etc/nixos"
 
 # Create modules directory if it doesn't exist


### PR DESCRIPTION
Update source directory paths in deploy.sh and GitHub workflow
script to use absolute paths. This change ensures consistent
behavior across different environments and improves reliability
of the deployment process.