### PR TITLE
feat: Add HTTP and HTTPS ports to firewall

### DIFF
--- a/modules/ssh.nix
+++ b/modules/ssh.nix
@@ -32,6 +32,6 @@
 
   networking.firewall = {
     enable = true;
-    allowedTCPPorts = [ 22222 ];  # Allow only the SSH port
+    allowedTCPPorts = [ 22222, 80, 443 ];  # Allow only the SSH and HTTP(S) ports
   };
 }


### PR DESCRIPTION
Allow incoming connections on ports 80 and 443 in addition to
the existing SSH port. This change enables the system to serve
web content and handle secure HTTPS traffic, expanding its
network capabilities while maintaining SSH access.