### PR TITLE
fix: correct syntax for allowedTCPPorts

### DIFF
--- a/modules/ssh.nix
+++ b/modules/ssh.nix
@@ -32,6 +32,6 @@
 
   networking.firewall = {
     enable = true;
-    allowedTCPPorts = [ 22222, 80, 443 ];  # Allow only the SSH and HTTP(S) ports
+    allowedTCPPorts = [ 22222 80 443 ];  # Allow only the SSH and HTTP(S) ports
   };
 }


### PR DESCRIPTION
Replace commas with spaces in the allowedTCPPorts list to
ensure proper parsing of the configuration. This change
maintains the same port allowances (SSH and HTTP/HTTPS) while
adhering to the correct NixOS syntax for firewall rules.