### PR TITLE
feat: Replace ffmpeg_7-full with ffmpeg

### DIFF
--- a/modules/packages.nix
+++ b/modules/packages.nix
@@ -6,6 +6,6 @@
     btop
     nano
     git
-    ffmpeg_7-full
+    ffmpeg
   ];
 }


### PR DESCRIPTION
Replace the specific version of ffmpeg (ffmpeg_7-full) with the
standard ffmpeg package. This change simplifies package management
and ensures compatibility with the latest version of ffmpeg.
The update allows for easier maintenance and potential performance
improvements.